### PR TITLE
11679 tad filter duration logic

### DIFF
--- a/components/listingsPage/filters.js
+++ b/components/listingsPage/filters.js
@@ -7,6 +7,7 @@ import {
   resolveMedia,
   Form,
   Tooltip,
+  Paragraph,
 } from "@moneypensionservice/directories";
 
 import styled from "styled-components";
@@ -83,9 +84,11 @@ const Filters = ({ t }) => {
   const [land_55_days_max_age, changeLandMax55] = useState({});
 
   const filtersValues = [
+    age,
     trip_type,
     cover_area,
     how_far_in_advance_trip_cover_weeks,
+    tripLength,
     will_cover_undergoing_treatment,
     will_cover_terminal_prognosis,
     will_cover_specialist_equipment,
@@ -96,6 +99,23 @@ const Filters = ({ t }) => {
     land_45_days_max_age,
     land_55_days_max_age,
   ];
+  // console.log(tripLength);
+
+  const [annual, changeAnnualShow] = useState(true);
+  const [single, changeSingleShow] = useState(true);
+  const [note, changeNote] = useState(true);
+
+  const SingleTrip = styled.div`
+    display: ${(props) => (props.single ? "block" : "none")};
+  `;
+  const AnnualTrip = styled.div`
+    display: ${(props) => (props.annual ? "block" : "none")};
+  `;
+
+  const Note = styled.span`
+    display: ${(props) => (props.note ? "block" : "none")};
+    font-size: 12px;
+  `;
 
   const dispatch = useDispatch();
 
@@ -130,13 +150,24 @@ const Filters = ({ t }) => {
 
   const handleInsuranceType = (e) => {
     let trip_type = e.target.value;
+
     changeInsuranceType({ trip_type });
+    if (trip_type === "Single Trip") {
+      changeSingleShow(true);
+      changeAnnualShow(false);
+      changeNote(false);
+    }
+    if (trip_type === "Annual Multi-trip") {
+      changeAnnualShow(true);
+      changeSingleShow(false);
+      changeNote(false);
+    }
   };
 
-  // const handleTripLength = (e) => {
-  //   let tripLength = e.target.value;
-  //   changeTripLength({ tripLength });
-  // };
+  const handleTripLength = (e) => {
+    let tripLength = e.target.value;
+    changeTripLength({ tripLength });
+  };
 
   const handleDestination = (e) => {
     let cover_area = e.target.value;
@@ -184,6 +215,9 @@ const Filters = ({ t }) => {
     changeLandMax45({});
     changeLandMax55({});
     changeAge({ age: "" });
+    changeAnnualShow(false);
+    changeSingleShow(false);
+    changeNote(true);
   };
 
   return (
@@ -237,24 +271,115 @@ const Filters = ({ t }) => {
             {ageRange()}
           </Select>
         </FilterFormFIeld>
-        <FilterFormFIeld>
-          <Legend>
-            {t("headings.filter_by_insurance_type")}
-            <Tooltip minWidth="300px" hover text={insuranceTypeTip} />
-          </Legend>
-          {t("filters.trip_type", { returnObjects: true }).map(
-            ({ type, value }, i) => (
-              <Radio
-                key={i}
-                checked={trip_type.trip_type === value}
-                onChange={(e) => handleInsuranceType(e)}
-                label={type}
-                name="trip_type"
-                value={value}
-              />
-            )
-          )}
-        </FilterFormFIeld>
+        {/* Client Insurance Type */}
+        {process.browser ? (
+          <FilterFormFIeld>
+            <Legend>
+              {t("headings.filter_by_insurance_type")}
+              <Tooltip minWidth="300px" hover text={insuranceTypeTip} />
+            </Legend>
+            {t("filters.trip_type", { returnObjects: true }).map(
+              ({ type, value }, i) => (
+                <Radio
+                  key={i}
+                  checked={trip_type.trip_type === value}
+                  onChange={(e) => handleInsuranceType(e)}
+                  label={type}
+                  name="trip_type"
+                  value={value}
+                />
+              )
+            )}
+            <Heading level={4}>
+              {t("headings.filter_by_length_of_trip")}
+            </Heading>
+            <Note note={note}>Please select the type of insurance first</Note>
+            <SingleTrip single={single}>
+              {t("filters.singleTripLength", { returnObjects: true }).map(
+                ({ length, value }, i) => (
+                  <Radio
+                    key={i}
+                    checked={tripLength.tripLength === value}
+                    onChange={(e) => handleTripLength(e)}
+                    label={length}
+                    name="tripLength"
+                    id={`length-${i}`}
+                    value={value}
+                  />
+                )
+              )}
+            </SingleTrip>
+            <AnnualTrip annual={annual}>
+              <span style={{ fontSize: "14px" }}>for each individual trip</span>
+
+              {t("filters.annualTripLength", { returnObjects: true }).map(
+                ({ length, value }, i) => (
+                  <Radio
+                    key={i}
+                    checked={tripLength.tripLength === value}
+                    onChange={(e) => handleTripLength(e)}
+                    label={length}
+                    name="tripLength"
+                    id={`length-${i}`}
+                    value={value}
+                  />
+                )
+              )}
+            </AnnualTrip>
+          </FilterFormFIeld>
+        ) : (
+          <FilterFormFIeld>
+            <Legend>{t("headings.filter_by_insurance_type")}</Legend>
+            {t("filters.trip_type", { returnObjects: true }).map(
+              ({ type, value }, i) => (
+                <Radio
+                  key={i}
+                  checked={trip_type.trip_type === value}
+                  onChange={(e) => handleInsuranceType(e)}
+                  label={type}
+                  name="trip_type"
+                  value={value}
+                />
+              )
+            )}
+            <Heading level={4}>
+              {t("headings.filter_by_length_of_trip")}
+            </Heading>
+            <Paragraph textSize="12px">
+              Choose only if you selected Single Trip
+            </Paragraph>
+            {t("filters.singleTripLength", { returnObjects: true }).map(
+              ({ length, value }, i) => (
+                <Radio
+                  style={{ fontSize: "13px" }}
+                  key={i}
+                  checked={tripLength.tripLength === value}
+                  onChange={(e) => handleTripLength(e)}
+                  label={length}
+                  name="tripLength"
+                  value={value}
+                />
+              )
+            )}
+            <Paragraph textSize="12px" style={{ marginTop: "20px" }}>
+              Choose only if you selected Annual Multi-trip
+            </Paragraph>
+            {t("filters.annualTripLength", { returnObjects: true }).map(
+              ({ length, value }, i) => (
+                <Radio
+                  style={{ fontSize: "13px" }}
+                  key={i}
+                  checked={tripLength.tripLength === value}
+                  onChange={(e) => handleTripLength(e)}
+                  label={length}
+                  name="tripLength"
+                  value={value}
+                />
+              )
+            )}
+          </FilterFormFIeld>
+        )}
+
         {/* <FilterFormFIeld>
           <Legend>
             {t("headings.filter_by_length_of_trip")}

--- a/components/listingsPage/filters.js
+++ b/components/listingsPage/filters.js
@@ -89,7 +89,7 @@ const Filters = ({ t }) => {
     age,
     trip_type,
     cover_area,
-    // cruise,
+    cruise,
     how_far_in_advance_trip_cover_weeks,
     singleOption,
     annualOption,
@@ -103,7 +103,7 @@ const Filters = ({ t }) => {
     land_45_days_max_age,
     land_55_days_max_age,
   ];
-  console.log(cruise);
+  // console.log(filtersValues);
 
   const [annual, changeAnnualShow] = useState(false);
   const [single, changeSingleShow] = useState(false);

--- a/components/listingsPage/filters.js
+++ b/components/listingsPage/filters.js
@@ -105,8 +105,8 @@ const Filters = ({ t }) => {
   ];
   console.log(cruise);
 
-  const [annual, changeAnnualShow] = useState(true);
-  const [single, changeSingleShow] = useState(true);
+  const [annual, changeAnnualShow] = useState(false);
+  const [single, changeSingleShow] = useState(false);
   const [note, changeNote] = useState(true);
 
   const SingleTrip = styled.div`

--- a/components/listingsPage/filters.js
+++ b/components/listingsPage/filters.js
@@ -68,6 +68,8 @@ const Filters = ({ t }) => {
   const [age, changeAge] = useState({});
   const [trip_type, changeInsuranceType] = useState({});
   const [tripLength, changeTripLength] = useState({});
+  const [singleOption, changeSingleOption] = useState({});
+  const [annualOption, changeAnnualOption] = useState({});
   const [cover_area, changeDestination] = useState({});
   const [cruise, changeCruise] = useState({});
   const [how_far_in_advance_trip_cover_weeks, changeWhen] = useState({});
@@ -87,8 +89,10 @@ const Filters = ({ t }) => {
     age,
     trip_type,
     cover_area,
+    // cruise,
     how_far_in_advance_trip_cover_weeks,
-    tripLength,
+    singleOption,
+    annualOption,
     will_cover_undergoing_treatment,
     will_cover_terminal_prognosis,
     will_cover_specialist_equipment,
@@ -99,7 +103,7 @@ const Filters = ({ t }) => {
     land_45_days_max_age,
     land_55_days_max_age,
   ];
-  // console.log(tripLength);
+  console.log(cruise);
 
   const [annual, changeAnnualShow] = useState(true);
   const [single, changeSingleShow] = useState(true);
@@ -140,9 +144,6 @@ const Filters = ({ t }) => {
     dispatch(filterOfferings(filtersValues));
   }, [filtersValues]);
 
-  // console.log(offerings);
-  // console.log(cruise_30_days_max_age);
-
   const handleAge = (e) => {
     let age = e.target.value;
     changeAge({ age });
@@ -164,9 +165,16 @@ const Filters = ({ t }) => {
     }
   };
 
-  const handleTripLength = (e) => {
-    let tripLength = e.target.value;
-    changeTripLength({ tripLength });
+  const handleSingleOption = (e) => {
+    let singleOption = e.target.value;
+    changeSingleOption({ singleOption });
+    changeAnnualOption({});
+  };
+
+  const handleAnnualOption = (e) => {
+    let annualOption = e.target.value;
+    changeAnnualOption({ annualOption });
+    changeSingleOption({});
   };
 
   const handleDestination = (e) => {
@@ -174,10 +182,10 @@ const Filters = ({ t }) => {
     changeDestination({ cover_area });
   };
 
-  // const handleCruise = (e) => {
-  //   let cruise = e.target.value;
-  //   changeCruise({ cruise });
-  // };
+  const handleCruise = (e) => {
+    let cruise = e.target.value;
+    changeCruise({ cruise });
+  };
 
   const handleWhen = (e) => {
     let how_far_in_advance_trip_cover_weeks = e.target.value;
@@ -201,7 +209,8 @@ const Filters = ({ t }) => {
 
   const clearFilters = () => {
     changeInsuranceType({});
-    changeTripLength({});
+    changeSingleOption({});
+    changeAnnualOption({});
     changeDestination({});
     changeCruise({});
     changeWhen({});
@@ -299,11 +308,10 @@ const Filters = ({ t }) => {
                 ({ length, value }, i) => (
                   <Radio
                     key={i}
-                    checked={tripLength.tripLength === value}
-                    onChange={(e) => handleTripLength(e)}
+                    checked={singleOption.singleOption === value}
+                    onChange={(e) => handleSingleOption(e)}
                     label={length}
-                    name="tripLength"
-                    id={`length-${i}`}
+                    name="singleOption"
                     value={value}
                   />
                 )
@@ -316,11 +324,10 @@ const Filters = ({ t }) => {
                 ({ length, value }, i) => (
                   <Radio
                     key={i}
-                    checked={tripLength.tripLength === value}
-                    onChange={(e) => handleTripLength(e)}
+                    checked={annualOption.annualOption === value}
+                    onChange={(e) => handleAnnualOption(e)}
                     label={length}
-                    name="tripLength"
-                    id={`length-${i}`}
+                    name="annualOption"
                     value={value}
                   />
                 )
@@ -380,25 +387,6 @@ const Filters = ({ t }) => {
           </FilterFormFIeld>
         )}
 
-        {/* <FilterFormFIeld>
-          <Legend>
-            {t("headings.filter_by_length_of_trip")}
-            <Tooltip hover text="To be supplied" />
-          </Legend>
-          {t("filters.tripLength", { returnObjects: true }).map(
-            ({ length, value }, i) => (
-              <Radio
-                key={i}
-                checked={tripLength.tripLength === value}
-                onChange={(e) => handleTripLength(e)}
-                label={length}
-                name="tripLength"
-                id={`length-${i}`}
-                value={value}
-              />
-            )
-          )}
-        </FilterFormFIeld> */}
         <FilterFormFIeld>
           <Legend>
             {t("headings.destination")}
@@ -417,7 +405,7 @@ const Filters = ({ t }) => {
             )
           )}
         </FilterFormFIeld>
-        {/* <FilterFormFIeld>
+        <FilterFormFIeld>
           <Legend>
             {t("headings.is_your_trip_a_cruise")}?
             <Tooltip hover text="To be supplied" />
@@ -435,7 +423,7 @@ const Filters = ({ t }) => {
               />
             )
           )}
-        </FilterFormFIeld> */}
+        </FilterFormFIeld>
         <FilterFormFIeld>
           <Legend>
             {t("headings.when_are_you_travelling")}?

--- a/components/listingsPage/redux/actions.js
+++ b/components/listingsPage/redux/actions.js
@@ -43,10 +43,12 @@ export const filterOfferings = (pool) => {
     const offerings = getState().listings.offerings.hits;
     const firms = getState().listings.firms.hits;
 
-    console.log(offerings);
+    // console.log(offerings);
 
     // remove empty object from dispatched filter values
     const filteredPool = pool.filter((value) => Object.keys(value).length != 0);
+
+    console.log(filteredPool);
 
     //  dispatch firm if filteredPool is empty
     if (filteredPool.length == 0) {
@@ -60,12 +62,17 @@ export const filterOfferings = (pool) => {
     if (filteredPool.length > 0) {
       // obtain the selected offering through filteredPool
       const selectedOfferings = filteredPool.reduce((acc, value) => {
+        // let age = value.cruise_30_days_max_age;
+        // console.log(age);
+
         return acc.filter((offering) => {
           for (var key in value) {
+            // console.log(key);
             if (typeof value[key] === "number") {
+              // console.log(age);
               let subtitle = parseInt(offering[Object.keys(value)]);
               return (
-                subtitle <= 1000 ||
+                subtitle === 1000 ||
                 Object.values(value)[0] <= offering.cruise_30_days_max_age ||
                 Object.values(value)[0] <= offering.cruise_45_days_max_age ||
                 Object.values(value)[0] <= offering.cruise_55_days_max_age ||
@@ -77,9 +84,26 @@ export const filterOfferings = (pool) => {
             if (key === "how_far_in_advance_trip_cover_weeks") {
               return Object.values(value)[0] <= parseInt(offering[key]);
             }
-            return offering[Object.keys(value)].includes(
-              Object.values(value)[0]
-            );
+            if (key === "tripLength") {
+              let land = "land_" + Object.values(value)[0] + "_days_max_age";
+              let cruise =
+                "cruise_" + Object.values(value)[0] + "_days_max_age";
+
+              console.log(value);
+              console.log(`${offering[land]}`, `${offering[cruise]}`);
+
+              return (
+                Object.values(value)[0] <= offering.cruise_30_days_max_age ||
+                Object.values(value)[0] <= offering.cruise_45_days_max_age ||
+                Object.values(value)[0] <= offering.cruise_55_days_max_age ||
+                Object.values(value)[0] <= offering.land_30_days_max_age ||
+                Object.values(value)[0] <= offering.land_45_days_max_age ||
+                Object.values(value)[0] <= offering.land_55_days_max_age
+              );
+            }
+            // return offering[Object.keys(value)].includes(
+            //   Object.values(value)[0]
+            // );
           }
         });
       }, offerings);

--- a/components/listingsPage/redux/actions.js
+++ b/components/listingsPage/redux/actions.js
@@ -48,8 +48,15 @@ export const filterOfferings = (pool) => {
     // remove empty object from dispatched filter values
     const filteredPool = pool.filter((value) => Object.keys(value).length != 0);
 
-    console.log(filteredPool);
+    let age = 0;
+    filteredPool.map((fill) => {
+      if (fill.age) {
+        age = fill.age;
+      }
+    });
+    filteredPool.shift();
 
+    // console.log(parseInt(age));
     //  dispatch firm if filteredPool is empty
     if (filteredPool.length == 0) {
       dispatch({
@@ -63,11 +70,10 @@ export const filterOfferings = (pool) => {
       // obtain the selected offering through filteredPool
       const selectedOfferings = filteredPool.reduce((acc, value) => {
         // let age = value.cruise_30_days_max_age;
-        // console.log(age);
 
         return acc.filter((offering) => {
           for (var key in value) {
-            // console.log(key);
+            // console.log(age);
             if (typeof value[key] === "number") {
               // console.log(age);
               let subtitle = parseInt(offering[Object.keys(value)]);
@@ -84,26 +90,40 @@ export const filterOfferings = (pool) => {
             if (key === "how_far_in_advance_trip_cover_weeks") {
               return Object.values(value)[0] <= parseInt(offering[key]);
             }
-            if (key === "tripLength") {
+
+            if (key === "singleOption" || key === "annualOption") {
               let land = "land_" + Object.values(value)[0] + "_days_max_age";
               let cruise =
                 "cruise_" + Object.values(value)[0] + "_days_max_age";
+              // let l = `${offering[land]}`;
+              // let c = `${offering[cruise]}`;
 
-              console.log(value);
-              console.log(`${offering[land]}`, `${offering[cruise]}`);
+              // console.log(typeof parseInt(l), typeof parseInt(c));
+
+              console.log(
+                age,
+                `${offering[land]}`,
+                `${offering[cruise]}`,
+                age >= parseInt(`${offering[land]}`),
+                age >= parseInt(`${offering[cruise]}`),
+                parseInt(`${offering[cruise]}`) === 1000,
+                parseInt(`${offering[land]}`) === 1000,
+
+                offering.objectID
+              );
 
               return (
-                Object.values(value)[0] <= offering.cruise_30_days_max_age ||
-                Object.values(value)[0] <= offering.cruise_45_days_max_age ||
-                Object.values(value)[0] <= offering.cruise_55_days_max_age ||
-                Object.values(value)[0] <= offering.land_30_days_max_age ||
-                Object.values(value)[0] <= offering.land_45_days_max_age ||
-                Object.values(value)[0] <= offering.land_55_days_max_age
+                ((parseInt(`${offering[land]}`) != -1 ||
+                  parseInt(`${offering[cruise]}`) != -1) &&
+                  age >= parseInt(`${offering[land]}`)) ||
+                age >= parseFloat(`${offering[cruise]}`) ||
+                parseInt(`${offering[land]}`) === 1000 ||
+                parseFloat(`${offering[cruise]}`) === 1000
               );
             }
-            // return offering[Object.keys(value)].includes(
-            //   Object.values(value)[0]
-            // );
+            return offering[Object.keys(value)].includes(
+              Object.values(value)[0]
+            );
           }
         });
       }, offerings);

--- a/components/listingsPage/redux/actions.js
+++ b/components/listingsPage/redux/actions.js
@@ -46,7 +46,11 @@ export const filterOfferings = (pool) => {
     // console.log(offerings);
 
     // remove empty object from dispatched filter values
-    const filteredPool = pool.filter((value) => Object.keys(value).length != 0);
+    const filteredPool = pool.filter((value) => Object.keys(value).length > 0);
+
+    var myArrayFiltered = pool.filter((ele) => {
+      return ele.constructor === Object && Object.keys(ele).length > 0;
+    });
 
     let age = 0;
     filteredPool.map((fill) => {
@@ -56,7 +60,9 @@ export const filterOfferings = (pool) => {
     });
 
     // remove age from filteredPool
-    filteredPool.shift();
+    if (age !== 0) {
+      filteredPool.shift();
+    }
 
     //  dispatch firm if filteredPool is empty
     if (filteredPool.length == 0) {
@@ -93,18 +99,6 @@ export const filterOfferings = (pool) => {
               let cruise =
                 "cruise_" + Object.values(value)[0] + "_days_max_age";
 
-              console.log(
-                age,
-                `${offering[land]}`,
-                `${offering[cruise]}`,
-                age >= parseInt(`${offering[land]}`),
-                age >= parseInt(`${offering[cruise]}`),
-                parseInt(`${offering[cruise]}`) === 1000,
-                parseInt(`${offering[land]}`) === 1000,
-
-                offering.objectID
-              );
-
               return (
                 (parseInt(`${offering[land]}`) != -1 ||
                   parseInt(`${offering[cruise]}`) != -1) &&
@@ -112,6 +106,27 @@ export const filterOfferings = (pool) => {
                   age >= parseFloat(`${offering[cruise]}`) ||
                   parseInt(`${offering[land]}`) === 1000 ||
                   parseFloat(`${offering[cruise]}`) === 1000)
+              );
+            }
+
+            if (key === "cruise" && Object.values(value)[0] === "Yes") {
+              return (
+                ((parseInt(offering.cruise_30_days_max_age) != -1 ||
+                  parseInt(offering.cruise_30_days_max_age) != -1 ||
+                  parseInt(offering.cruise_30_days_max_age) != -1) &&
+                  age >= parseInt(offering.cruise_30_days_max_age)) ||
+                age >= parseInt(offering.cruise_45_days_max_age) ||
+                age >= parseInt(offering.cruise_55_days_max_age)
+              );
+            }
+            if (key === "cruise" && Object.values(value)[0] === "No") {
+              return (
+                ((parseInt(offering.land_30_days_max_age) != -1 ||
+                  parseInt(offering.land_30_days_max_age) != -1 ||
+                  parseInt(offering.land_30_days_max_age) != -1) &&
+                  age >= parseInt(offering.land_30_days_max_age)) ||
+                age >= parseInt(offering.land_45_days_max_age) ||
+                age >= parseInt(offering.land_55_days_max_age)
               );
             }
             return offering[Object.keys(value)].includes(

--- a/components/listingsPage/redux/actions.js
+++ b/components/listingsPage/redux/actions.js
@@ -54,9 +54,10 @@ export const filterOfferings = (pool) => {
         age = fill.age;
       }
     });
+
+    // remove age from filteredPool
     filteredPool.shift();
 
-    // console.log(parseInt(age));
     //  dispatch firm if filteredPool is empty
     if (filteredPool.length == 0) {
       dispatch({
@@ -69,13 +70,9 @@ export const filterOfferings = (pool) => {
     if (filteredPool.length > 0) {
       // obtain the selected offering through filteredPool
       const selectedOfferings = filteredPool.reduce((acc, value) => {
-        // let age = value.cruise_30_days_max_age;
-
         return acc.filter((offering) => {
           for (var key in value) {
-            // console.log(age);
             if (typeof value[key] === "number") {
-              // console.log(age);
               let subtitle = parseInt(offering[Object.keys(value)]);
               return (
                 subtitle === 1000 ||
@@ -95,10 +92,6 @@ export const filterOfferings = (pool) => {
               let land = "land_" + Object.values(value)[0] + "_days_max_age";
               let cruise =
                 "cruise_" + Object.values(value)[0] + "_days_max_age";
-              // let l = `${offering[land]}`;
-              // let c = `${offering[cruise]}`;
-
-              // console.log(typeof parseInt(l), typeof parseInt(c));
 
               console.log(
                 age,
@@ -113,12 +106,12 @@ export const filterOfferings = (pool) => {
               );
 
               return (
-                ((parseInt(`${offering[land]}`) != -1 ||
+                (parseInt(`${offering[land]}`) != -1 ||
                   parseInt(`${offering[cruise]}`) != -1) &&
-                  age >= parseInt(`${offering[land]}`)) ||
-                age >= parseFloat(`${offering[cruise]}`) ||
-                parseInt(`${offering[land]}`) === 1000 ||
-                parseFloat(`${offering[cruise]}`) === 1000
+                (age >= parseInt(`${offering[land]}`) ||
+                  age >= parseFloat(`${offering[cruise]}`) ||
+                  parseInt(`${offering[land]}`) === 1000 ||
+                  parseFloat(`${offering[cruise]}`) === 1000)
               );
             }
             return offering[Object.keys(value)].includes(

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -33,7 +33,7 @@ export default class MyDocument extends Document {
 
   render() {
     return (
-      <Html dir="ltr" lang={this.props.__NEXT_DATA__.props.initialLanguage}>
+      <Html dir="ltr">
         <Head />
         <body>
           <Main />

--- a/public/static/locales/cy/listings.json
+++ b/public/static/locales/cy/listings.json
@@ -9,11 +9,15 @@
       { "type": "Trip Sengl", "value": "Single Trip" },
       { "type": "Aml-Daith Flynyddol", "value": "Annual Multi-trip" }
     ],
-    "tripLength": [
-      { "length": "Dan 35 diwrnod", "value": "Under 35 Days" },
-      { "length": "Dan 45 diwrnod", "value": "Under 45 Days" },
-      { "length": "Dan 55 diwrnod", "value": "Under 55 Days" },
-      { "length": "Dros 6 mis", "value": "Over 6 months" }
+    "singleTripLength": [
+      { "length": "Hyd at 1 mis", "value": "30" },
+      { "length": "1 - 6 mis", "value": "180" },
+      { "length": "DDros 6 mis", "value": "181" }
+    ],
+    "annualTripLength": [
+      { "length": "Heb fod yn hwy na 31 diwrnod", "value": "31" },
+      { "length": "Heb fod yn hwy na 45 diwrnod", "value": "45" },
+      { "length": "DHeb fod yn hwy na 55 diwrnod", "value": "55" }
     ],
     "cover_area": [
       { "location": "DU ac Ewrop", "value": "United Kingdom & Europe" },
@@ -56,7 +60,7 @@
     "clear": "Yn glir",
     "age_at_time_of_travel": "Oedran adeg teithio",
     "filter_by_insurance_type": "Hidlo yn ôl math o yswiriant",
-    "filter_by_length_of_trip": "Hidlo yn ôl hyd y daith",
+    "filter_by_length_of_trip": "Hyd y daith",
     "destination": "Cyrchfan",
     "is_your_trip_a_cruise": "A yw eich taith yn fordaith",
     "when_are_you_travelling": "Pryd wyt ti'n teithio",

--- a/public/static/locales/en/listings.json
+++ b/public/static/locales/en/listings.json
@@ -9,11 +9,15 @@
       { "type": "Single Trip", "value": "Single Trip" },
       { "type": "Annual Multi-Trip", "value": "Annual Multi-trip" }
     ],
-    "tripLength": [
-      { "length": "Under 35 Days", "value": "Under 35 Days" },
-      { "length": "Under 45 Days", "value": "Under 45 Days" },
-      { "length": "Under 55 Days", "value": "Under 55 Days" },
-      { "length": "Over 6 months", "value": "Over 6 months" }
+    "singleTripLength": [
+      { "length": "Up to 1 month", "value": "30" },
+      { "length": "1 - 6 months", "value": "45" },
+      { "length": "Over 6 months", "value": "55" }
+    ],
+    "annualTripLength": [
+      { "length": "No longer than 31 days", "value": "30" },
+      { "length": "No longer than 45 days", "value": "45" },
+      { "length": "No longer than 55 days", "value": "55" }
     ],
     "cover_area": [
       { "location": "UK & Europe", "value": "United Kingdom & Europe" },
@@ -57,7 +61,7 @@
     "clear": "Clear",
     "age_at_time_of_travel": "Age at time of travel",
     "filter_by_insurance_type": "Filter by insurance type",
-    "filter_by_length_of_trip": "Filter by length of trip",
+    "filter_by_length_of_trip": "Length of trip",
     "destination": "Destination",
     "is_your_trip_a_cruise": "Is your trip a cruise",
     "when_are_you_travelling": "When are you travelling",


### PR DESCRIPTION
[TP11679](https://maps.tpondemand.com/RestUI/Board.aspx#page=board/5682182231901749200&appConfig=eyJhY2lkIjoiNzlGODk3MENDQkM0N0FCM0ZFQzkyNEVFODEyREM0M0EifQ==&boardPopup=userstory/11679/silent)

This PR implements the `Length of trip` filter that depends on the `Filter by insurance type` filters' response. The options shown are dependent on whether the user selected `Single Trip` or `Annual Multi-trip`. The results on the right side are also filtered on the basis of response selected.
It also added the cruise filter and its data logic.