### PR TITLE
Renamed instances of moneyadviceservices.org.uk to moneyhelper.org

### DIFF
--- a/Utils/layouts/index.js
+++ b/Utils/layouts/index.js
@@ -146,7 +146,7 @@ const Breadcrumb = ({ path, t }) => {
     <BreadcrumbSection align="stretch">
       <Section constrained>
         <Col style={{ display: "inline" }}>
-          <BreadAnchor href="https://www.moneyadviceservice.org.uk/en" data-testid="breadAnchor">
+          <BreadAnchor href="https://www.moneyhelper.org/en" data-testid="breadAnchor">
             {t("home")}
           </BreadAnchor >
           <BreadLink href="/" name={t("travel")} />

--- a/components/global.test.js
+++ b/components/global.test.js
@@ -1,8 +1,8 @@
 import { shallow } from "enzyme";
-import   {MyApp } from "../pages/_app"
+import   {MyApp } from "../pages/_app";
 import AppHead from "../Utils/layouts/head";
-import { PageFooter} from "../components/footer"
-import BreadCrumb, {BreadAnchor, BreadLink} from "../Utils/layouts"
+import { PageFooter} from "../components/footer";
+import BreadCrumb, {BreadAnchor, BreadLink} from "../Utils/layouts";
 import * as nextRouter from 'next/router';
 import { findByTestAtrr} from "../Utils/test";
 
@@ -80,7 +80,7 @@ describe("Breadcrumb", () => {
         const bread = shallow(<BreadCrumb {...props}/>).dive()
         const MAS = bread.find(BreadAnchor)
         expect(
-            MAS.findWhere((node) => node.prop("href") === "https://www.moneyadviceservice.org.uk/en")
+            MAS.findWhere((node) => node.prop("href") === "https://www.moneyhelper.org/en")
           ).toHaveLength(1);
         
     })

--- a/components/landingPage/landing.test.js
+++ b/components/landingPage/landing.test.js
@@ -45,12 +45,12 @@ describe("HomePage", () => {
 
   it("firms' register anchor should contain correct href", () => {
     expect(
-      wrapper.findWhere((node) => node.prop("href") === "https://radsignup.moneyadviceservice.org.uk/travel_insurance_registrations/new")
+      wrapper.findWhere((node) => node.prop("href") === "https://radsignup.moneyhelper.org/travel_insurance_registrations/new")
     ).toHaveLength(1);
   })
   it("firms' login anchor should contain correct href", () => {
     expect(
-      wrapper.findWhere((node) => node.prop("href") === "https://radsignup.moneyadviceservice.org.uk/users/sign_in")
+      wrapper.findWhere((node) => node.prop("href") === "https://radsignup.moneyhelper.org/users/sign_in")
     ).toHaveLength(1);
   })
   it("should have a button with href pointing to /listings ", () => {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -9,7 +9,7 @@ import Footer from "../components/footer";
 import Head from "../Utils/layouts/head";
 
 import { ThemeProvider, Container } from "@moneypensionservice/directories";
-import './tad_consumer_reskin.css'
+import './tad_consumer_reskin.css';
 
 
 const MyApp = ({

--- a/pages/index.js
+++ b/pages/index.js
@@ -57,14 +57,14 @@ const Homepage = ({ t, path }) => {
         <Col sizes={{ xs: 12, md: 3 }} data-testid="contentCol">
           <ParagraphAnchor style={{ fontSize: "16px" }}>
             <Anchor
-              href="https://radsignup.moneyadviceservice.org.uk/travel_insurance_registrations/new"
+              href="https://radsignup.moneyhelper.org/travel_insurance_registrations/new"
               style={{ fontSize: "16px" }}
             >
               {t("home.banner.register")}
             </Anchor>
             {t("home.banner.or")}
             <Anchor
-              href="https://radsignup.moneyadviceservice.org.uk/users/sign_in"
+              href="https://radsignup.moneyhelper.org/users/sign_in"
               style={{ fontSize: "16px" }}
             >
               {t("home.banner.login")}

--- a/public/static/locales/cy/footer.json
+++ b/public/static/locales/cy/footer.json
@@ -54,15 +54,15 @@
       },
       "link_items": [
         {
-          "href": "https://www.moneyadviceservice.org.uk/cy/static/amdanom-ni",
+          "href": "https://www.moneyhelper.org/cy/static/amdanom-ni",
           "text": "Amdanom ni"
         },
         {
-          "href": "https://www.moneyadviceservice.org.uk/cy/categories/our-debt-work",
+          "href": "https://www.moneyhelper.org/cy/categories/our-debt-work",
           "text": "Ein gwaith dyledion"
         },
         {
-          "href": "https://www.moneyadviceservice.org.uk/cy/static/canolfan-gyfryngau",
+          "href": "https://www.moneyhelper.org/cy/static/canolfan-gyfryngau",
           "text": "Canolfan y cyfryngau"
         },
         {
@@ -70,15 +70,15 @@
           "text": "Galluogrwydd Ariannol"
         },
         {
-          "href": "https://www.moneyadviceservice.org.uk/cy/categories/Partners",
+          "href": "https://www.moneyhelper.org/cy/categories/Partners",
           "text": "Partneriaid"
         },
         {
-          "href": "https://www.moneyadviceservice.org.uk/cy/static/swyddi",
+          "href": "https://www.moneyhelper.org/cy/static/swyddi",
           "text": "Swyddi"
         },
         {
-          "href": "https://www.moneyadviceservice.org.uk/cy/categories/tools-and-calculators",
+          "href": "https://www.moneyhelper.org/cy/categories/tools-and-calculators",
           "text": "Offer a chyfrifianellau"
         }
       ],
@@ -98,27 +98,27 @@
       },
       "list_items": [
         {
-          "href": "https://www.moneyadviceservice.org.uk/cy/static/cysylltu-a-ni",
+          "href": "https://www.moneyhelper.org/cy/static/cysylltu-a-ni",
           "text": "Cysylltu â ni"
         },
         {
-          "href": "https://www.moneyadviceservice.org.uk/cy/static/telerau-ac-amodau",
+          "href": "https://www.moneyhelper.org/cy/static/telerau-ac-amodau",
           "text": "Amodau a Thelerau"
         },
         {
-          "href": "https://www.moneyadviceservice.org.uk/cy/corporate/polisipreifatrwydd",
+          "href": "https://www.moneyhelper.org/cy/corporate/polisipreifatrwydd",
           "text": "Rhybudd preifatrwydd"
         },
         {
-          "href": "https://www.moneyadviceservice.org.uk/cy/static/hygyrchedd",
+          "href": "https://www.moneyhelper.org/cy/static/hygyrchedd",
           "text": "Hygyrchedd"
         },
         {
-          "href": "https://www.moneyadviceservice.org.uk/cy/static/cookie_notice_cy",
+          "href": "https://www.moneyhelper.org/cy/static/cookie_notice_cy",
           "text": "Cwcis"
         },
         {
-          "href": "https://www.moneyadviceservice.org.uk/cy/static/canolfan-gyfryngau",
+          "href": "https://www.moneyhelper.org/cy/static/canolfan-gyfryngau",
           "text": "Map safle"
         }
       ]

--- a/public/static/locales/cy/landing.json
+++ b/public/static/locales/cy/landing.json
@@ -116,20 +116,20 @@
       "links": [
         {
           "text": "Yswiriant Teithio pan fydd gennych gyflwr meddygol difrifol",
-          "href": "https://www.moneyadviceservice.org.uk/cy/articles/travel-insurance-if-you-have-a-medical-condition"
+          "href": "https://www.moneyhelper.org/cy/articles/travel-insurance-if-you-have-a-medical-condition"
         },
         {
           "text": "Oes angen yswiriant teithio arnoch?",
-          "href": "https://www.moneyadviceservice.org.uk/cy/articles/a-oes-arnoch-angen-yswiriant-teithio"
+          "href": "https://www.moneyhelper.org/cy/articles/a-oes-arnoch-angen-yswiriant-teithio"
         },
         {
           "text": "Yswiriant teithio i bobl dros 65 oed",
-          "href": "https://www.moneyadviceservice.org.uk/cy/articles/yswiriant-teithio-ar-gyfer-pobl-dros-65-oed-a-chyflyrau-meddygol"
+          "href": "https://www.moneyhelper.org/cy/articles/yswiriant-teithio-ar-gyfer-pobl-dros-65-oed-a-chyflyrau-meddygol"
         },
 
         {
           "text": "Coronafeirws ac yswiriant teithio",
-          "href": "https://www.moneyadviceservice.org.uk/cy/articles/coronafeirws-ac-yswiriant-teithio"
+          "href": "https://www.moneyhelper.org/cy/articles/coronafeirws-ac-yswiriant-teithio"
         }
       ]
     },

--- a/public/static/locales/en/footer.json
+++ b/public/static/locales/en/footer.json
@@ -54,15 +54,15 @@
       },
       "link_items": [
         {
-          "href": "https://www.moneyadviceservice.org.uk/en/static/about-us",
+          "href": "https://www.moneyhelper.org/en/static/about-us",
           "text": "About us"
         },
         {
-          "href": "https://www.moneyadviceservice.org.uk/en/categories/our-debt-work",
+          "href": "https://www.moneyhelper.org/en/categories/our-debt-work",
           "text": "Our debt work"
         },
         {
-          "href": "https://www.moneyadviceservice.org.uk/en/static/media-centre",
+          "href": "https://www.moneyhelper.org/en/static/media-centre",
           "text": "Media centre"
         },
         {
@@ -70,15 +70,15 @@
           "text": "Financial Capability"
         },
         {
-          "href": "https://www.moneyadviceservice.org.uk/en/categories/partners",
+          "href": "https://www.moneyhelper.org/en/categories/partners",
           "text": "Partners"
         },
         {
-          "href": "https://www.moneyadviceservice.org.uk/en/static/jobs",
+          "href": "https://www.moneyhelper.org/en/static/jobs",
           "text": "Jobs"
         },
         {
-          "href": "https://www.moneyadviceservice.org.uk/en/categories/tools-and-calculators",
+          "href": "https://www.moneyhelper.org/en/categories/tools-and-calculators",
           "text": "Tools & Calculators"
         }
       ],
@@ -98,27 +98,27 @@
       },
       "list_items": [
         {
-          "href": "https://www.moneyadviceservice.org.uk/en/static/contact-us",
+          "href": "https://www.moneyhelper.org/en/static/contact-us",
           "text": "Contact us"
         },
         {
-          "href": "https://www.moneyadviceservice.org.uk/en/static/terms-and-conditions",
+          "href": "https://www.moneyhelper.org/en/static/terms-and-conditions",
           "text": "Terms & Conditions"
         },
         {
-          "href": "https://www.moneyadviceservice.org.uk/en/corporate/privacy",
+          "href": "https://www.moneyhelper.org/en/corporate/privacy",
           "text": "Privacy Notice"
         },
         {
-          "href": "https://www.moneyadviceservice.org.uk/en/static/accessibility",
+          "href": "https://www.moneyhelper.org/en/static/accessibility",
           "text": "Accessibility"
         },
         {
-          "href": "https://www.moneyadviceservice.org.uk/en/static/cookie_notice_en",
+          "href": "https://www.moneyhelper.org/en/static/cookie_notice_en",
           "text": "Cookies"
         },
         {
-          "href": "https://www.moneyadviceservice.org.uk/en/sitemap",
+          "href": "https://www.moneyhelper.org/en/sitemap",
           "text": "Sitemap"
         }
       ]

--- a/public/static/locales/en/landing.json
+++ b/public/static/locales/en/landing.json
@@ -115,20 +115,20 @@
       "links": [
         {
           "text": "Travel Insurance when you have a serious medical condition",
-          "href": "https://www.moneyadviceservice.org.uk/en/articles/travel-insurance-if-you-have-a-medical-condition"
+          "href": "https://www.moneyhelper.org/en/articles/travel-insurance-if-you-have-a-medical-condition"
         },
         {
           "text": "Do you need travel insurance?",
-          "href": "https://www.moneyadviceservice.org.uk/en/articles/do-you-need-travel-insurance"
+          "href": "https://www.moneyhelper.org/en/articles/do-you-need-travel-insurance"
         },
         {
           "text": "Travel insurance for the over 65s",
-          "href": "https://www.moneyadviceservice.org.uk/en/articles/travel-insurance-for-over-65s-and-medical-conditions"
+          "href": "https://www.moneyhelper.org/en/articles/travel-insurance-for-over-65s-and-medical-conditions"
         },
 
         {
           "text": "Coronavirus and travel insurance",
-          "href": "https://www.moneyadviceservice.org.uk/en/articles/coronavirus-and-travel-insurance"
+          "href": "https://www.moneyhelper.org/en/articles/coronavirus-and-travel-insurance"
         }
       ]
     },


### PR DESCRIPTION
- Renamed instances of moneyadviceservice.org.uk to moneyhelper.org

Some things have been left unchanged for now:

- `public/static/locales/cy/footer.json:87` (and the corresponding `en.yml`) - The Money Advice Service has been left untouched as the name of the organisation, should this be changed?
- `public/static/locales/en/header.json:4` - The Money Advice Service across key1 and key2 has been left untouched.