### PR TITLE
IE11: Travel Insurance Directory - Missing Styles

### DIFF
--- a/Utils/layouts/ie11.js
+++ b/Utils/layouts/ie11.js
@@ -1,0 +1,2 @@
+// Use this media query to target only IE10 & IE11 browsers. IE11 Specific CSS can go within this media query
+export const mediaDetectIE11 = 'all and (-ms-high-contrast: none), (-ms-high-contrast: active)';

--- a/components/landingPage/faq.js
+++ b/components/landingPage/faq.js
@@ -1,6 +1,7 @@
 import React, { Fragment, useState } from "react";
 import styled from "styled-components";
 import { Accordion } from "@moneypensionservice/directories";
+import { mediaDetectIE11 } from "../../Utils/layouts/ie11";
 
 // styled components
 
@@ -11,6 +12,10 @@ const AEMAccordion = styled(Accordion)`
         border-bottom:1px solid #9DA1CA;
     }
     button{
+        @media ${mediaDetectIE11} {
+          min-height: 35px;
+          max-height: 58px;
+        }
         flex-direction: row-reverse;
         justify-content: space-between;
     }

--- a/components/listingsPage/utils.js
+++ b/components/listingsPage/utils.js
@@ -12,6 +12,7 @@ import {
   Pagination
 } from "@moneypensionservice/directories";
 import { AEMAnchor as Anchor } from "../landingPage/subComponents"
+import { mediaDetectIE11 } from "../../Utils/layouts/ie11";
 
 export const AEMRadio = styled(Radio)`
     color: #000;
@@ -395,6 +396,10 @@ export const AEMCompanyCard = styled(CompanyCard)`
                 font-weight: 700;
                 border: 1px solid #C82A87;
                 box-shadow: 0px 3px 0px rgba(0, 11, 59, 0.25);
+
+                @media ${mediaDetectIE11} {
+                  height: 50px;
+                }
                 
                 &:hover{
                     background: #F3F1F3;


### PR DESCRIPTION
IE11: Travel Insurance Directory - Missing Styles
There are two fixes in this branch:

**1) Accordion fix**

![TAD-Styling fix1-heroku-staging](https://user-images.githubusercontent.com/70527659/154956783-93f28b3b-7a14-47c6-8ca6-cc249476a943.jpg)

**2) Card button fixes**

![TAD-Styling fix2-heroku-staging](https://user-images.githubusercontent.com/70527659/154956939-ea5c4652-bab2-44e6-985b-65756637c5ca.jpg)
