### PR TITLE
Fix columns for IE11 InfoTable, YouTube, AEMCompanyCard

### DIFF
--- a/components/landingPage/brokerTable.js
+++ b/components/landingPage/brokerTable.js
@@ -9,11 +9,13 @@ import {
 } from "@moneypensionservice/directories";
 
 const AEMInfoTable = styled(InfoTable)`
+    width: 100%;
     border: 1px solid #9DA1CA;
     border-bottom-left-radius: 25px;
     h3{
         font-weight: 600;
-    padding-top: 30px
+    padding-top: 30px;
+    }
 `;
 
 const BrokerTable = ({ content, ...rest }) => (

--- a/components/landingPage/subComponents.js
+++ b/components/landingPage/subComponents.js
@@ -102,6 +102,7 @@ const QuestionButton = styled(Button)`
 const YoutubeFrame = styled.iframe.attrs((props) => ({
   frameBorder: 0,
   height: 315,
+  width: '100%'
 }))`
   position: relative;
   top: 0;

--- a/components/listingsPage/utils.js
+++ b/components/listingsPage/utils.js
@@ -380,6 +380,10 @@ export const AEMCompanyCard = styled(CompanyCard)`
     padding: 25px;
     border-bottom-left-radius: 25px;
     border: 1px solid #9DA1CA;
+    @media ${mediaDetectIE11} {
+      width: 100%;
+    }
+
         a{
             color: #00788F;
             font-weight: 600;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2099,9 +2099,9 @@
       }
     },
     "@moneypensionservice/directories": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@moneypensionservice/directories/-/directories-2.0.1.tgz",
-      "integrity": "sha512-B4/0yXGxgN+/RLtqi8HH3ElESijRE+ZAtQ5njEMQ8Tsee9TdL/tA3QIBK5/7Q8EyVmUtmcgAIS7dXrdoqc7TLA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@moneypensionservice/directories/-/directories-2.0.4.tgz",
+      "integrity": "sha512-DEAGKEBFgRuEUeJvgsdELMSow8cTRCxl/CyCVh/itsx4hvbS2scLTKV/l8ciwazOIUovzM8QuyVjyHk3LKGfig==",
       "requires": {
         "@babel/runtime": "^7.8.4",
         "axios": "^0.20.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.2",
-    "@moneypensionservice/directories": "^2.0.1",
+    "@moneypensionservice/directories": "^2.0.4",
     "@react-pdf/renderer": "^1.6.11",
     "@react-pdf/styled-components": "^1.4.0",
     "@svgr/webpack": "^5.5.0",


### PR DESCRIPTION
Fix columns for IE11 InfoTable, YouTube, AEMCompanyCard

- fixed missing } in css
- Bump '@moneypensionservice/directories' to 2.0.4

This has been tested in staging and is ready for production.